### PR TITLE
Colored mixedconsole (fixed some one-off errors)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+### C++ objects and libs
+*.slo
+*.lo
+*.o
+*.a
+*.la
+*.lai
+*.so
+*.dll
+*.dylib
+
+### Qt-es
+/.qmake.cache
+/.qmake.stash
+*.pro.user
+*.pro.user.*
+*.qbs.user
+*.qbs.user.*
+*.moc
+moc_*.cpp
+qrc_*.cpp
+ui_*.h
+Makefile*
+*build-*
+
+### QtCreator
+*.autosave
+
+### QtCtreator Qml
+*.qmlproject.user
+*.qmlproject.user.*
+
+### QtCtreator CMake
+CMakeLists.txt.user

--- a/ScriptCommunicator/.gitignore
+++ b/ScriptCommunicator/.gitignore
@@ -1,2 +1,0 @@
-*.pro.user
-../build-ScriptCommunicator-Desktop-*/

--- a/ScriptCommunicator/mainwindow.cpp
+++ b/ScriptCommunicator/mainwindow.cpp
@@ -3181,13 +3181,6 @@ void MainWindow::appendConsoleStringToConsole(QString* consoleString, QTextEdit*
         //Store the scroll bar position.
         int val = textEdit->verticalScrollBar()->value();
 
-        if (textEdit == m_userInterface->ReceiveTextEditMixed)
-        {
-            consoleString->prepend("<body bgcolor=#ceecee>");
-            consoleString->append("</body>");
-        }
-
-
         textEdit->moveCursor(QTextCursor::End);
         textEdit->insertHtml(*consoleString);
         textEdit->moveCursor(QTextCursor::End);

--- a/ScriptCommunicator/mainwindow.cpp
+++ b/ScriptCommunicator/mainwindow.cpp
@@ -1110,6 +1110,10 @@ void MainWindow::loadSettings()
                         currentSettings.consoleSendColor = node.attributes().namedItem("consoleSendColor").nodeValue();
                         currentSettings.consoleBackgroundColor = node.attributes().namedItem("consoleBackgroundColor").nodeValue();
                         currentSettings.consoleMessageAndTimestampColor = node.attributes().namedItem("consoleMessageAndTimestampColor").nodeValue();
+                        currentSettings.consoleMessageAsciiColor = node.attributes().namedItem("consoleMessageAsciiColor").nodeValue();
+                        currentSettings.consoleMessageDecimalColor = node.attributes().namedItem("consoleMessageDecimalColor").nodeValue();
+                        currentSettings.consoleMessageHexadecimalColor = node.attributes().namedItem("consoleMessageHexadecimalColor").nodeValue();
+                        currentSettings.consoleMessageBinaryColor = node.attributes().namedItem("consoleMessageBinaryColor").nodeValue();
                         currentSettings.consoleNewLineAfterBytes = node.attributes().namedItem("consoleNewLineAfterBytes").nodeValue().toUInt();
                         currentSettings.consoleNewLineAfterPause = node.attributes().namedItem("consoleNewLineAfterPause").nodeValue().toUInt();
                         currentSettings.consoleSendOnEnter = node.attributes().namedItem("consoleSendOnEnter").nodeValue();
@@ -1785,6 +1789,10 @@ void MainWindow::inititializeTab(void)
     static QString sendColor = "";
     static QString backgroundColor = "";
     static QString messageAndTimestampColor = "";
+    static QString messageAsciiColor = "";
+    static QString messageDecimalColor = "";
+    static QString messageHexadecimalColor = "";
+    static QString messageBinaryColor = "";
     static QString consoleFont = "";
     static QString stringConsoleFontSize = "";
     static DecimalType  consoleDecimalsType = DECIMAL_TYPE_UINT8;
@@ -1839,6 +1847,30 @@ void MainWindow::inititializeTab(void)
     {
         tabsChanged = true;
         messageAndTimestampColor = currentSettings->consoleMessageAndTimestampColor;
+    }
+
+    if(messageAsciiColor != currentSettings->consoleMessageAsciiColor)
+    {
+        tabsChanged = true;
+        messageAsciiColor = currentSettings->consoleMessageAsciiColor;
+    }
+
+    if(messageDecimalColor != currentSettings->consoleMessageDecimalColor)
+    {
+        tabsChanged = true;
+        messageDecimalColor = currentSettings->consoleMessageDecimalColor;
+    }
+
+    if(messageHexadecimalColor != currentSettings->consoleMessageHexadecimalColor)
+    {
+        tabsChanged = true;
+        messageHexadecimalColor = currentSettings->consoleMessageHexadecimalColor;
+    }
+
+    if(messageBinaryColor != currentSettings->consoleMessageBinaryColor)
+    {
+        tabsChanged = true;
+        messageBinaryColor = currentSettings->consoleMessageBinaryColor;
     }
 
     if(showAsciiInConsole != currentSettings->showAsciiInConsole)
@@ -2103,6 +2135,10 @@ void MainWindow::saveSettings()
                  std::make_pair(QString("consoleSendColor"), QString("%1").arg(currentSettings->consoleSendColor)),
                  std::make_pair(QString("consoleBackgroundColor"), QString("%1").arg(currentSettings->consoleBackgroundColor)),
                  std::make_pair(QString("consoleMessageAndTimestampColor"), QString("%1").arg(currentSettings->consoleMessageAndTimestampColor)),
+                 std::make_pair(QString("consoleMessageAsciiColor"), QString("%1").arg(currentSettings->consoleMessageAsciiColor)),
+                 std::make_pair(QString("consoleMessageDecimalColor"), QString("%1").arg(currentSettings->consoleMessageDecimalColor)),
+                 std::make_pair(QString("consoleMessageHexadecimalColor"), QString("%1").arg(currentSettings->consoleMessageHexadecimalColor)),
+                 std::make_pair(QString("consoleMessageBinaryColor"), QString("%1").arg(currentSettings->consoleMessageBinaryColor)),
                  std::make_pair(QString("consoleNewLineAfterBytes"), QString("%1").arg(currentSettings->consoleNewLineAfterBytes)),
                  std::make_pair(QString("consoleNewLineAfterPause"), QString("%1").arg(currentSettings->consoleNewLineAfterPause)),
                  std::make_pair(QString("consoleNewLineAt"), QString("%1").arg(currentSettings->consoleNewLineAt)),

--- a/ScriptCommunicator/mainwindow.ui
+++ b/ScriptCommunicator/mainwindow.ui
@@ -1678,15 +1678,12 @@ to send a sequence double click on it</string>
    <addaction name="menuHelp"/>
   </widget>
   <action name="actionConnect">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
    <property name="icon">
     <iconset resource="ScriptCommunicator.qrc">
      <normaloff>:/connect</normaloff>:/connect</iconset>
    </property>
    <property name="text">
-    <string>&amp;Connect</string>
+    <string>Connect</string>
    </property>
    <property name="toolTip">
     <string>connect</string>
@@ -1701,7 +1698,7 @@ to send a sequence double click on it</string>
      <normaloff>:/images/settings.png</normaloff>:/images/settings.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Settings</string>
+    <string>Settings</string>
    </property>
    <property name="toolTip">
     <string>settings</string>
@@ -1731,7 +1728,7 @@ to send a sequence double click on it</string>
      <normaloff>:/images/application-exit.png</normaloff>:/images/application-exit.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Quit</string>
+    <string>Quit</string>
    </property>
    <property name="toolTip">
     <string>quit</string>
@@ -1746,7 +1743,7 @@ to send a sequence double click on it</string>
      <normaloff>:/images/send.ico</normaloff>:/images/send.ico</iconset>
    </property>
    <property name="text">
-    <string>S&amp;end</string>
+    <string>Send</string>
    </property>
    <property name="toolTip">
     <string>send window</string>
@@ -1761,7 +1758,7 @@ to send a sequence double click on it</string>
      <normaloff>:/images/scripts.ico</normaloff>:/images/scripts.ico</iconset>
    </property>
    <property name="text">
-    <string>Sc&amp;ripts</string>
+    <string>Scripts</string>
    </property>
    <property name="toolTip">
     <string>script window</string>
@@ -1784,7 +1781,7 @@ to send a sequence double click on it</string>
      <normaloff>:/images/lock.ico</normaloff>:/images/lock.ico</iconset>
    </property>
    <property name="text">
-    <string>&amp;Lock</string>
+    <string>Lock</string>
    </property>
    <property name="iconText">
     <string>Lock</string>
@@ -1810,7 +1807,7 @@ to send a sequence double click on it</string>
      <normaloff>:/images/message.ico</normaloff>:/images/message.ico</iconset>
    </property>
    <property name="text">
-    <string>&amp;Message</string>
+    <string>Message</string>
    </property>
    <property name="iconText">
     <string>Message</string>
@@ -1900,7 +1897,7 @@ to send a sequence double click on it</string>
      <normaloff>:/images/BringToTop.ico</normaloff>:/images/BringToTop.ico</iconset>
    </property>
    <property name="text">
-    <string>&amp;Top</string>
+    <string>Top</string>
    </property>
    <property name="toolTip">
     <string>bring all windows to top</string>
@@ -1922,7 +1919,7 @@ to send a sequence double click on it</string>
      <normaloff>:/images/reopen.ico</normaloff>:/images/reopen.ico</iconset>
    </property>
    <property name="text">
-    <string>L&amp;ogs</string>
+    <string>Logs</string>
    </property>
    <property name="toolTip">
     <string>close and reopen all enabled logs (if the 'append time stamp at log file name'

--- a/ScriptCommunicator/mainwindowHandleData.cpp
+++ b/ScriptCommunicator/mainwindowHandleData.cpp
@@ -159,7 +159,7 @@ void MainWindowHandleData::updateConsoleAndLog(void)
  * @param data
  *      The data.
  * @param isSend
- *      True if the data has been send and false if the data has been received.
+ *      True if the data has been sent and false if the data has been received.
  * @param isUserMessage
  *      True if the data is a user message.
  * @param isFromCan
@@ -359,7 +359,7 @@ void MainWindowHandleData::calculateMixedConsoleData()
     }
     else
     {
-        qint32 numberOfSpaces = (m_mixedConsoleData.divider - 1);
+        qint32 numberOfSpaces = (m_mixedConsoleData.divider - 2);
         if(currentSettings->showDecimalInConsole && ! currentSettings->showBinaryConsole)
         {
             numberOfSpaces = 0;
@@ -390,7 +390,7 @@ void MainWindowHandleData::calculateMixedConsoleData()
     }
     else
     {
-        qint32 numberOfSpaces = (m_mixedConsoleData.divider - 2);
+        qint32 numberOfSpaces = (m_mixedConsoleData.divider - 3);
         if(currentSettings->showDecimalInConsole && ! currentSettings->showBinaryConsole)
         {
             numberOfSpaces = 0;
@@ -418,12 +418,12 @@ void MainWindowHandleData::calculateMixedConsoleData()
     {
         qint32 numberOfSpaces = 0;
 
-        if(currentSettings->consoleDecimalsType == DECIMAL_TYPE_UINT8){numberOfSpaces = currentSettings->showBinaryConsole ? 6 : 1;}
-        else if(currentSettings->consoleDecimalsType == DECIMAL_TYPE_INT8){numberOfSpaces = currentSettings->showBinaryConsole ? 5 : 1;}
-        else if(currentSettings->consoleDecimalsType == DECIMAL_TYPE_UINT16){numberOfSpaces = currentSettings->showBinaryConsole ? 13 : 1;}
-        else if(currentSettings->consoleDecimalsType == DECIMAL_TYPE_INT16){numberOfSpaces = currentSettings->showBinaryConsole ? 12 : 1;}
-        else if(currentSettings->consoleDecimalsType == DECIMAL_TYPE_UINT32){numberOfSpaces = currentSettings->showBinaryConsole ? 26 : 1;}
-        else{numberOfSpaces = currentSettings->showBinaryConsole ? 25 : 1;}
+        if(currentSettings->consoleDecimalsType == DECIMAL_TYPE_UINT8){numberOfSpaces = currentSettings->showBinaryConsole ? 5 : 1;}
+        else if(currentSettings->consoleDecimalsType == DECIMAL_TYPE_INT8){numberOfSpaces = currentSettings->showBinaryConsole ? 4 : 1;}
+        else if(currentSettings->consoleDecimalsType == DECIMAL_TYPE_UINT16){numberOfSpaces = currentSettings->showBinaryConsole ? 12 : 1;}
+        else if(currentSettings->consoleDecimalsType == DECIMAL_TYPE_INT16){numberOfSpaces = currentSettings->showBinaryConsole ? 11 : 1;}
+        else if(currentSettings->consoleDecimalsType == DECIMAL_TYPE_UINT32){numberOfSpaces = currentSettings->showBinaryConsole ? 25 : 1;}
+        else{numberOfSpaces = currentSettings->showBinaryConsole ? 24 : 1;}
 
         for(int i = 0; i < numberOfSpaces; i++)
         {
@@ -445,6 +445,7 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
 {
     QString result;
     QString tmpString;
+    QChar tmpChar;
     const Settings* currentSettings = m_settingsDialog->settings();
 
     if(m_mixedConsoleData.onlyOneType)
@@ -489,19 +490,34 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
                 ///Create the ascii string.
                 for(int i = 0; i < tmpString.length(); i++)
                 {
+                    tmpChar = tmpString[i];
+                    asciiString += "&nbsp;";
+                    asciiString += "<span style=background-color:cyan>";
                     if(!m_mixedConsoleData.asciiExtraSpaces.isEmpty() && ((i % modulo) == 0))
                     {
                        asciiString += m_mixedConsoleData.asciiExtraSpaces;
                     }
-                    asciiString += m_mixedConsoleData.asciiSpaces;
-                    asciiString += tmpString[i];
-                }
 
+                    asciiString += m_mixedConsoleData.asciiSpaces;
+                    // replace tags so our span does not get mangled up
+                    if (tmpChar == '<')
+                        asciiString += "&lt;";
+                    else if (tmpChar == '>')
+                        asciiString += "&gt;";
+                    else
+                        asciiString += tmpChar;
+                    asciiString += "</span>";
+                }
+/*
                 asciiString.replace("<", "&lt;");
                 asciiString.replace(">", "&gt;");
                 asciiString.replace(" ", "&nbsp;");
                 asciiString.replace("\n", " ");
-
+                asciiString.replace("\r", " ");
+                asciiString.replace("&", "&amp;");
+                asciiString.replace("\"", "&quot;");
+                asciiString.replace("\'", "&#39;");
+*/
                 result += asciiString;
             }
 
@@ -515,12 +531,15 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
                 qint32 modulo = m_mixedConsoleData.bytesPerDecimal;
                 for(int i = 0; i < list.length(); i++)
                 {
+                    result += "&nbsp;";
+                    result += "<span style=background-color:lightseagreen>";
                     if(!m_mixedConsoleData.hexExtraSpaces.isEmpty() && ((i % modulo) == 0))
                     {
                        result += m_mixedConsoleData.hexExtraSpaces;
                     }
                     result += m_mixedConsoleData.hexSpaces;
                     result += list[i];
+                    result += "</span>";
                 }
             }
 
@@ -534,8 +553,11 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
                 QStringList list = tmpString.split(" ");
                 for(auto el : list)
                 {
+                    result += "&nbsp;";
+                    result += "<span style=background-color:powderblue>";
                     result += m_mixedConsoleData.decimalSpaces;
                     result += el;
+                    result += "</span>";
                 }
             }
             if(currentSettings->showBinaryConsole)
@@ -547,7 +569,9 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
                 for(auto el : list)
                 {
                     result += "&nbsp;";
+                    result += "<span style=background-color:lavender>";
                     result += el;
+                    result += "</span>";
                 }
             }
 
@@ -559,6 +583,7 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
 
     return result;
 }
+
 /**
  * Appends data to the console buffers (m_consoleDataBufferAscii, m_consoleDataBufferHex;
  * m_consoleDataBufferDec)
@@ -1447,7 +1472,6 @@ void MainWindowHandleData::processDataInStoredData()
 
     for(auto el : m_unprocessedConsoleData)
     {
-
         if(el.type == STORED_DATA_CLEAR_ALL_STANDARD_CONSOLES)
         {
             m_userInterface->ReceiveTextEditAscii->clear();
@@ -1469,8 +1493,6 @@ void MainWindowHandleData::processDataInStoredData()
         else
            {
             bool isFromAddMessageDialog = (el.type == STORED_DATA_TYPE_USER_MESSAGE) ? true : false;
-
-
             bool isTimeStamp = (el.type == STORED_DATA_TYPE_TIMESTAMP) ? true : false;
             bool isNewLine = (el.type == STORED_DATA_TYPE_NEW_LINE) ? true : false;
 
@@ -1497,7 +1519,7 @@ void MainWindowHandleData::processDataInStoredData()
                         array.remove(0, settings->consoleNewLineAfterBytes - m_bytesSinceLastNewLineInConsole);
 
                         tmpArray = QString("\n").toLocal8Bit();
-                        //Save the console data bevore calling appendDataToConsoleStrings (0 are replace by 0xff in this function).
+                        //Save the console data before calling appendDataToConsoleStrings (0 are replace by 0xff in this function).
                         storedData.data = tmpArray;
                         storedData.type = STORED_DATA_TYPE_NEW_LINE;
                         m_storedConsoleData.push_back(storedData);

--- a/ScriptCommunicator/mainwindowHandleData.cpp
+++ b/ScriptCommunicator/mainwindowHandleData.cpp
@@ -292,30 +292,30 @@ void MainWindowHandleData::calculateMixedConsoleData()
 
     if(currentSettings->showBinaryConsole)
     {
-        m_mixedConsoleData.divider = 9;
+        m_mixedConsoleData.divider = 8;
         m_mixedConsoleData.onlyOneType = (!currentSettings->showHexInConsole && !currentSettings->showAsciiInConsole && !currentSettings->showDecimalInConsole) ? true : false;
     }
     else if(currentSettings->showDecimalInConsole)
     {
         if(currentSettings->consoleDecimalsType == DECIMAL_TYPE_UINT8)
         {
-           m_mixedConsoleData.divider = 4;
+           m_mixedConsoleData.divider = 3;
         }
         else if(currentSettings->consoleDecimalsType == DECIMAL_TYPE_INT8)
         {
-           m_mixedConsoleData.divider = 5;
+           m_mixedConsoleData.divider = 4;
         }
         else if(currentSettings->consoleDecimalsType == DECIMAL_TYPE_INT16)
         {
-           m_mixedConsoleData.divider = (7.0 / 2.0);
+           m_mixedConsoleData.divider = (6.0 / 2.0);
         }
         else if(currentSettings->consoleDecimalsType == DECIMAL_TYPE_UINT32)
         {
-           m_mixedConsoleData.divider = (11.0 / 4.0);
+           m_mixedConsoleData.divider = (10.0 / 4.0);
         }
         else
         {
-            m_mixedConsoleData.divider = 3;
+            m_mixedConsoleData.divider = 2;
         }
         m_mixedConsoleData.onlyOneType = (!currentSettings->showHexInConsole && !currentSettings->showAsciiInConsole) ? true : false;
     }
@@ -359,7 +359,7 @@ void MainWindowHandleData::calculateMixedConsoleData()
     }
     else
     {
-        qint32 numberOfSpaces = (m_mixedConsoleData.divider - 2);
+        qint32 numberOfSpaces = (m_mixedConsoleData.divider - 1);
         if(currentSettings->showDecimalInConsole && ! currentSettings->showBinaryConsole)
         {
             numberOfSpaces = 0;
@@ -390,7 +390,7 @@ void MainWindowHandleData::calculateMixedConsoleData()
     }
     else
     {
-        qint32 numberOfSpaces = (m_mixedConsoleData.divider - 3);
+        qint32 numberOfSpaces = (m_mixedConsoleData.divider - 2);
         if(currentSettings->showDecimalInConsole && ! currentSettings->showBinaryConsole)
         {
             numberOfSpaces = 0;
@@ -446,6 +446,7 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
     QString result;
     QString tmpString;
     QChar tmpChar;
+    const QString unprintable = "\r\n\t ";
     const Settings* currentSettings = m_settingsDialog->settings();
 
     if(m_mixedConsoleData.onlyOneType)
@@ -491,7 +492,7 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
                 for(int i = 0; i < tmpString.length(); i++)
                 {
                     tmpChar = tmpString[i];
-                    asciiString += "&nbsp;";
+                    asciiString += "&nbsp;";    // uncolored
                     asciiString += QString("<span style=background-color:#%1>").arg(currentSettings->consoleMessageAsciiColor);
                     if(!m_mixedConsoleData.asciiExtraSpaces.isEmpty() && ((i % modulo) == 0))
                     {
@@ -504,6 +505,8 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
                         asciiString += "&lt;";
                     else if (tmpChar == '>')
                         asciiString += "&gt;";
+                    else if (unprintable.contains(tmpChar))
+                        asciiString += ".";
                     else
                         asciiString += tmpChar;
                     asciiString += "</span>";
@@ -531,7 +534,7 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
                 qint32 modulo = m_mixedConsoleData.bytesPerDecimal;
                 for(int i = 0; i < list.length(); i++)
                 {
-                    result += "&nbsp;";
+                    result += "&nbsp;";     // uncolored
                     result += QString("<span style=background-color:#%1>").arg(currentSettings->consoleMessageHexadecimalColor);
                     if(!m_mixedConsoleData.hexExtraSpaces.isEmpty() && ((i % modulo) == 0))
                     {
@@ -553,7 +556,7 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
                 QStringList list = tmpString.split(" ");
                 for(auto el : list)
                 {
-                    result += "&nbsp;";
+                    result += "&nbsp;";     // uncolored
                     result += QString("<span style=background-color:#%1>").arg(currentSettings->consoleMessageDecimalColor);
                     result += m_mixedConsoleData.decimalSpaces;
                     result += el;
@@ -568,7 +571,7 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
                 QStringList list = tmpString.split(" ");
                 for(auto el : list)
                 {
-                    result += "&nbsp;";
+                    result += "&nbsp;";     // uncolored
                     result += QString("<span style=background-color:#%1>").arg(currentSettings->consoleMessageBinaryColor);
                     result += el;
                     result += "</span>";

--- a/ScriptCommunicator/mainwindowHandleData.cpp
+++ b/ScriptCommunicator/mainwindowHandleData.cpp
@@ -492,7 +492,7 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
                 {
                     tmpChar = tmpString[i];
                     asciiString += "&nbsp;";
-                    asciiString += "<span style=background-color:cyan>";
+                    asciiString += QString("<span style=background-color:#%1>").arg(currentSettings->consoleMessageAsciiColor);
                     if(!m_mixedConsoleData.asciiExtraSpaces.isEmpty() && ((i % modulo) == 0))
                     {
                        asciiString += m_mixedConsoleData.asciiExtraSpaces;
@@ -532,7 +532,7 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
                 for(int i = 0; i < list.length(); i++)
                 {
                     result += "&nbsp;";
-                    result += "<span style=background-color:lightseagreen>";
+                    result += QString("<span style=background-color:#%1>").arg(currentSettings->consoleMessageHexadecimalColor);
                     if(!m_mixedConsoleData.hexExtraSpaces.isEmpty() && ((i % modulo) == 0))
                     {
                        result += m_mixedConsoleData.hexExtraSpaces;
@@ -554,7 +554,7 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
                 for(auto el : list)
                 {
                     result += "&nbsp;";
-                    result += "<span style=background-color:powderblue>";
+                    result += QString("<span style=background-color:#%1>").arg(currentSettings->consoleMessageDecimalColor);
                     result += m_mixedConsoleData.decimalSpaces;
                     result += el;
                     result += "</span>";
@@ -569,7 +569,7 @@ QString MainWindowHandleData::createMixedConsoleString(const QByteArray &data, b
                 for(auto el : list)
                 {
                     result += "&nbsp;";
-                    result += "<span style=background-color:lavender>";
+                    result += QString("<span style=background-color:#%1>").arg(currentSettings->consoleMessageBinaryColor);
                     result += el;
                     result += "</span>";
                 }
@@ -672,7 +672,6 @@ void MainWindowHandleData::appendDataToConsoleStrings(QByteArray &data, bool isS
                 }
 
                 canInformation = "<br>id: " +  messageIdString + " type: " + typeString + "   ";
-
             }
 
             if(isSend){canArray.remove(0, PCANBasicClass::BYTES_METADATA_SEND);}
@@ -747,8 +746,6 @@ void MainWindowHandleData::appendDataToConsoleStrings(QByteArray &data, bool isS
             dataStringAscii.replace("\r", "");
             dataStringAscii = canInformation + dataStringAscii;
         }
-
-
     }
 
     //Note: data/dataArray is modified during the creation of dataStringAscii (see above), therefore data/dataArray must not be used.

--- a/ScriptCommunicator/settingsdialog.h
+++ b/ScriptCommunicator/settingsdialog.h
@@ -31,6 +31,7 @@
 #include <QLabel>
 #include <QToolButton>
 #include <QComboBox>
+#include <QSignalMapper>
 
 QT_USE_NAMESPACE
 
@@ -219,6 +220,12 @@ struct Settings
     ///The color of timestamps and messages.
     QString consoleMessageAndTimestampColor;
 
+    ///Colors for mixed console
+    QString consoleMessageAsciiColor;
+    QString consoleMessageDecimalColor;
+    QString consoleMessageHexadecimalColor;
+    QString consoleMessageBinaryColor;
+
     ///New line after ... number of sent/received bytes (0=off).
     quint32 consoleNewLineAfterBytes;
 
@@ -380,7 +387,7 @@ public:
     QString getColorStringFromButton(QToolButton* button);
 
     ///Sets the text color of a button.
-    void setButtonTextColorFromString(QString colorString, QToolButton* button);
+    void setButtonColorFromString(QString colorString, QToolButton* button);
 
     ///Sets m_interfaceSettingsCanBeChanged.
     void setInterfaceSettingsCanBeChanged(bool interfaceSettingsCanBeChanged);
@@ -416,18 +423,6 @@ private slots:
 
     ///Is called if the user presses the search log script button.
     void searchLogScriptSlot();
-
-    ///Is called if the received color button button is pressed.
-    void receiveColorButtonPressedSlot(void);
-
-    ///Is called if the send color button button is pressed.
-    void sendColorButtonPressedSlot(void);
-
-    ///Is called if the message and timestamp color button button is pressed.
-    void messageAndTimestampColorButtonPressedSlot(void);
-
-    ///Is called if the background button is pressed.
-    void backgroundColorButtonPressedSlot(void);
 
     ///Is called if a filter radio button is pressed.
     void setFilterRadioButtonPressedSlot(void);
@@ -570,6 +565,7 @@ private:
 
     ///Reads the information from all available serial port.
     QVector<QStringList> getSerialPortsInfo();
+    QSignalMapper *mapColorButtons;
 
 private:
     ///The user interface.

--- a/ScriptCommunicator/settingsdialog.ui
+++ b/ScriptCommunicator/settingsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>779</width>
-    <height>528</height>
+    <width>873</width>
+    <height>648</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -35,176 +35,11 @@
    <iconset resource="ScriptCommunicator.qrc">
     <normaloff>:/images/settings.png</normaloff>:/images/settings.png</iconset>
   </property>
-  <layout class="QGridLayout" name="gridLayout_11">
-   <item row="1" column="1">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>general</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_8">
-      <property name="rightMargin">
-       <number>12</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_25">
-        <property name="statusTip">
-         <string>the current interface</string>
-        </property>
-        <property name="text">
-         <string>current interface</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="connectionTypeComboBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="statusTip">
-         <string>the current interface</string>
-        </property>
-        <property name="sizeAdjustPolicy">
-         <enum>QComboBox::AdjustToContents</enum>
-        </property>
-        <item>
-         <property name="text">
-          <string>serial port</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>socket</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>spi master</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>pcan</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="0" column="5">
-       <spacer name="horizontalSpacer_8">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="3" column="6">
-       <widget class="QPushButton" name="closeButton">
-        <property name="text">
-         <string>Close</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="6">
-       <widget class="QPushButton" name="searchScriptEditorPushButton">
-        <property name="text">
-         <string>search</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="QLabel" name="label_26">
-        <property name="toolTip">
-         <string>endianess of the connected device (is used to interpret the decimals
-in the log, the decimal console and the send window)</string>
-        </property>
-        <property name="text">
-         <string>endianness</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1" colspan="5">
-       <widget class="DragDropLineEdit" name="scriptEditorPathLineEdit">
-        <property name="toolTip">
-         <string>path to the external script editor</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_24">
-        <property name="text">
-         <string>script editor</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="4">
-       <widget class="QComboBox" name="endianessComboBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>endianess of the connected device (is used to interpret the decimals
-in the log, the decimal console and the send window)</string>
-        </property>
-        <property name="sizeAdjustPolicy">
-         <enum>QComboBox::AdjustToContents</enum>
-        </property>
-        <item>
-         <property name="text">
-          <string>little-endian</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>big-endian</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="2">
+  <layout class="QVBoxLayout" name="verticalLayout_8">
+   <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>5</number>
      </property>
      <widget class="QWidget" name="serialPortTab">
       <attribute name="title">
@@ -213,70 +48,6 @@ in the log, the decimal console and the send window)</string>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
         <widget class="QScrollArea" name="scrollArea_3">
-         <property name="palette">
-          <palette>
-           <active>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </active>
-           <inactive>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </inactive>
-           <disabled>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </disabled>
-          </palette>
-         </property>
          <property name="widgetResizable">
           <bool>true</bool>
          </property>
@@ -285,8 +56,8 @@ in the log, the decimal console and the send window)</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>735</width>
-            <height>347</height>
+            <width>793</width>
+            <height>412</height>
            </rect>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0">
@@ -619,70 +390,6 @@ in the log, the decimal console and the send window)</string>
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
         <widget class="QScrollArea" name="scrollArea_4">
-         <property name="palette">
-          <palette>
-           <active>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </active>
-           <inactive>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </inactive>
-           <disabled>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </disabled>
-          </palette>
-         </property>
          <property name="widgetResizable">
           <bool>true</bool>
          </property>
@@ -691,8 +398,8 @@ in the log, the decimal console and the send window)</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>735</width>
-            <height>347</height>
+            <width>780</width>
+            <height>423</height>
            </rect>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="0,1">
@@ -1160,70 +867,6 @@ for TCP clients.</string>
       <layout class="QVBoxLayout" name="verticalLayout_5">
        <item>
         <widget class="QScrollArea" name="scrollArea_5">
-         <property name="palette">
-          <palette>
-           <active>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </active>
-           <inactive>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </inactive>
-           <disabled>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </disabled>
-          </palette>
-         </property>
          <property name="widgetResizable">
           <bool>true</bool>
          </property>
@@ -1232,8 +875,8 @@ for TCP clients.</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>735</width>
-            <height>347</height>
+            <width>793</width>
+            <height>412</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_5" columnstretch="0,0,1">
@@ -1464,70 +1107,6 @@ for TCP clients.</string>
       <layout class="QVBoxLayout" name="verticalLayout_7">
        <item>
         <widget class="QScrollArea" name="scrollArea_6">
-         <property name="palette">
-          <palette>
-           <active>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </active>
-           <inactive>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </inactive>
-           <disabled>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </disabled>
-          </palette>
-         </property>
          <property name="widgetResizable">
           <bool>true</bool>
          </property>
@@ -1536,8 +1115,8 @@ for TCP clients.</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>735</width>
-            <height>347</height>
+            <width>793</width>
+            <height>412</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_6" rowstretch="1,1,1,1,0">
@@ -1792,70 +1371,6 @@ for TCP clients.</string>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
         <widget class="QScrollArea" name="scrollArea">
-         <property name="palette">
-          <palette>
-           <active>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </active>
-           <inactive>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </inactive>
-           <disabled>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </disabled>
-          </palette>
-         </property>
          <property name="widgetResizable">
           <bool>true</bool>
          </property>
@@ -1864,15 +1379,69 @@ for TCP clients.</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>718</width>
-            <height>435</height>
+            <width>862</width>
+            <height>573</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_9">
            <item row="0" column="0">
-            <layout class="QGridLayout" name="gridLayout_7" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0" columnstretch="0,0,0,0,0,1,0">
-             <item row="11" column="4">
-              <widget class="QComboBox" name="consoleTimestampAtByteComboBox">
+            <layout class="QGridLayout" name="gridLayout_7" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0" columnstretch="0,0,0,0,0,0,0,0">
+             <item row="5" column="0">
+              <widget class="QCheckBox" name="showCanTabCheckBox">
+               <property name="toolTip">
+                <string>show the can tab</string>
+               </property>
+               <property name="statusTip">
+                <string/>
+               </property>
+               <property name="text">
+                <string>can tab</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="2">
+              <widget class="QCheckBox" name="consoleShowCanMetaCheckBox">
+               <property name="toolTip">
+                <string>show can meta information (id and type) in conole</string>
+               </property>
+               <property name="text">
+                <string>can meta</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="2">
+              <widget class="QCheckBox" name="consoleShowDecimalCheckBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>show decimal console</string>
+               </property>
+               <property name="text">
+                <string>decimal</string>
+               </property>
+              </widget>
+             </item>
+             <item row="12" column="3" colspan="3">
+              <widget class="QLineEdit" name="ConsoleTimestampFormat">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>150</width>
+                 <height>0</height>
+                </size>
+               </property>
                <property name="maximumSize">
                 <size>
                  <width>16777215</width>
@@ -1880,11 +1449,89 @@ for TCP clients.</string>
                 </size>
                </property>
                <property name="toolTip">
-                <string>create time stamp at byte</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;time stamp format ('optinal new lines (\n)' date and time format (chapter Time format and Date format in the manual) 'optional new lines (\n)'&lt;/p&gt;&lt;p&gt;Example:&lt;/p&gt;&lt;p&gt;\nyyyy-MM-dd hh:mm:ss.zzz\n&lt;/p&gt;&lt;p&gt;Example without date and with spaces in front of the time stamp:&lt;/p&gt;&lt;p&gt;\n       hh:mm:ss\n&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>\nyyyy-MM-dd hh:mm:ss.zzz\n</string>
                </property>
               </widget>
              </item>
-             <item row="10" column="1">
+             <item row="14" column="0">
+              <spacer name="verticalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="15" column="0">
+              <widget class="QLabel" name="label">
+               <property name="toolTip">
+                <string>new line after x number of sent/received bytes (0=off)</string>
+               </property>
+               <property name="text">
+                <string>new line after x bytes</string>
+               </property>
+              </widget>
+             </item>
+             <item row="7" column="7">
+              <widget class="QPushButton" name="consoleEditScriptPushButton">
+               <property name="toolTip">
+                <string>edit custom console script</string>
+               </property>
+               <property name="text">
+                <string>edit</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="3">
+              <widget class="QCheckBox" name="consoleShowMixedCheckBox">
+               <property name="toolTip">
+                <string>show mixed console (ascii, dec and hex together in one console if they are selected)</string>
+               </property>
+               <property name="statusTip">
+                <string/>
+               </property>
+               <property name="text">
+                <string>mixed</string>
+               </property>
+              </widget>
+             </item>
+             <item row="9" column="2">
+              <spacer name="verticalSpacer_6">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="10" column="0">
+              <widget class="QLabel" name="ConsoleBufferLabel">
+               <property name="toolTip">
+                <string>max. characters in console</string>
+               </property>
+               <property name="text">
+                <string>max. characters</string>
+               </property>
+              </widget>
+             </item>
+             <item row="10" column="2">
               <widget class="QLineEdit" name="ConsoleBufferLineEdit">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
@@ -1906,56 +1553,21 @@ for TCP clients.</string>
                </property>
               </widget>
              </item>
-             <item row="11" column="1">
-              <widget class="QLineEdit" name="ConsoleUpdateIntervallLineEdit">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
+             <item row="23" column="4">
+              <spacer name="verticalSpacer_4">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
                </property>
-               <property name="maximumSize">
+               <property name="sizeHint" stdset="0">
                 <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
+                 <width>20</width>
+                 <height>40</height>
                 </size>
                </property>
-               <property name="toolTip">
-                <string>the update intervall of the consoles</string>
-               </property>
-              </widget>
+              </spacer>
              </item>
-             <item row="10" column="0">
-              <widget class="QLabel" name="ConsoleBufferLabel">
-               <property name="toolTip">
-                <string>max. characters in console</string>
-               </property>
-               <property name="text">
-                <string>max. characters</string>
-               </property>
-              </widget>
-             </item>
-             <item row="10" column="4">
-              <widget class="QLineEdit" name="PrintTimeStampLineEdit">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string>create time stamp after ms</string>
-               </property>
-              </widget>
-             </item>
-             <item row="10" column="2" colspan="2">
-              <widget class="QCheckBox" name="PrintTimeStampCheckBox">
+             <item row="0" column="2">
+              <widget class="QCheckBox" name="ShowReceivedCheckBox">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                  <horstretch>0</horstretch>
@@ -1963,28 +1575,92 @@ for TCP clients.</string>
                 </sizepolicy>
                </property>
                <property name="toolTip">
-                <string>create time stamp after ms</string>
+                <string>show received data in console</string>
                </property>
                <property name="text">
-                <string>create time stamp after ms</string>
+                <string>receive</string>
                </property>
                <property name="checked">
+                <bool>true</bool>
+               </property>
+               <property name="tristate">
                 <bool>false</bool>
                </property>
               </widget>
              </item>
-             <item row="11" column="0">
-              <widget class="QLabel" name="label_5">
+             <item row="3" column="2">
+              <widget class="QCheckBox" name="consoleShowHexCheckBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
                <property name="toolTip">
-                <string>the update interval of the consoles</string>
+                <string>show hexadecimal console</string>
                </property>
                <property name="text">
-                <string>update interval</string>
+                <string>hex</string>
                </property>
               </widget>
              </item>
-             <item row="14" column="0">
-              <spacer name="verticalSpacer_3">
+             <item row="16" column="0">
+              <widget class="QLabel" name="label_2">
+               <property name="toolTip">
+                <string>new line after x ms send/receive pause (0=off)</string>
+               </property>
+               <property name="text">
+                <string>new line after ms pause</string>
+               </property>
+              </widget>
+             </item>
+             <item row="16" column="2">
+              <widget class="QLineEdit" name="consoleNewLineAfterPause">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="toolTip">
+                <string>new line after x ms send/receive pause (0=off)</string>
+               </property>
+               <property name="text">
+                <string>0</string>
+               </property>
+              </widget>
+             </item>
+             <item row="16" column="4">
+              <widget class="QLabel" name="label_18">
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;this is sent/used for the enter key (console, message dialog, main window send area and ascii sequence in the send window)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>send on enter key</string>
+               </property>
+              </widget>
+             </item>
+             <item row="16" column="5">
+              <widget class="QComboBox" name="consoleSendOnEnter">
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;this is sent/used for the enter key (console, message dialog, main window send area and ascii sequence in the send window)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+              </widget>
+             </item>
+             <item row="20" column="4">
+              <spacer name="verticalSpacer">
                <property name="orientation">
                 <enum>Qt::Vertical</enum>
                </property>
@@ -1993,41 +1669,14 @@ for TCP clients.</string>
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
-                 <width>20</width>
+                 <width>13</width>
                  <height>20</height>
                 </size>
                </property>
               </spacer>
              </item>
-             <item row="21" column="0">
-              <layout class="QHBoxLayout" name="horizontalLayout_4">
-               <item>
-                <widget class="QToolButton" name="consoleSendColorButton">
-                 <property name="toolTip">
-                  <string>color of the sent data in the console</string>
-                 </property>
-                 <property name="autoFillBackground">
-                  <bool>true</bool>
-                 </property>
-                 <property name="text">
-                  <string>...</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="consoleSendColorLabel">
-                 <property name="toolTip">
-                  <string>color of the sent data in the consoles</string>
-                 </property>
-                 <property name="text">
-                  <string>send color</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item row="4" column="1">
-              <widget class="QCheckBox" name="consoleShowDecimalCheckBox">
+             <item row="3" column="0">
+              <widget class="QCheckBox" name="consoleShowAsciiCheckBox">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                  <horstretch>0</horstretch>
@@ -2035,40 +1684,27 @@ for TCP clients.</string>
                 </sizepolicy>
                </property>
                <property name="toolTip">
-                <string>show decimal console</string>
+                <string>show ascii console</string>
                </property>
                <property name="text">
-                <string>decimal</string>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="0">
-              <widget class="QCheckBox" name="showCanTabCheckBox">
-               <property name="toolTip">
-                <string>show the can tab</string>
-               </property>
-               <property name="statusTip">
-                <string/>
-               </property>
-               <property name="text">
-                <string>can tab</string>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="1">
-              <widget class="QCheckBox" name="consoleShowCanMetaCheckBox">
-               <property name="toolTip">
-                <string>show can meta information (id and type) in conole</string>
-               </property>
-               <property name="text">
-                <string>can meta</string>
+                <string>ascii</string>
                </property>
                <property name="checked">
                 <bool>true</bool>
                </property>
               </widget>
              </item>
-             <item row="4" column="2">
+             <item row="6" column="0">
+              <widget class="QCheckBox" name="consoleShowCustomCheckBox">
+               <property name="toolTip">
+                <string>show a custom console (see chapter custom console/log scripts for more details)</string>
+               </property>
+               <property name="text">
+                <string>custom</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="3">
               <widget class="QComboBox" name="consoleDecimalsType">
                <property name="toolTip">
                 <string>the type of the decimals in the decimal console</string>
@@ -2105,19 +1741,6 @@ for TCP clients.</string>
                </item>
               </widget>
              </item>
-             <item row="3" column="2">
-              <widget class="QCheckBox" name="consoleShowMixedCheckBox">
-               <property name="toolTip">
-                <string>show mixed console (ascii, dec and hex together in one console if they are selected)</string>
-               </property>
-               <property name="statusTip">
-                <string/>
-               </property>
-               <property name="text">
-                <string>mixed</string>
-               </property>
-              </widget>
-             </item>
              <item row="4" column="0">
               <widget class="QCheckBox" name="consoleShowBinaryCheckBox">
                <property name="toolTip">
@@ -2128,212 +1751,43 @@ for TCP clients.</string>
                </property>
               </widget>
              </item>
-             <item row="23" column="3">
-              <spacer name="verticalSpacer_4">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>40</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="6" column="0">
-              <widget class="QCheckBox" name="consoleShowCustomCheckBox">
+             <item row="6" column="2" colspan="5">
+              <widget class="DragDropLineEdit" name="consoleScriptLineEdit">
                <property name="toolTip">
-                <string>show a custom console (see chapter custom console/log scripts for more details)</string>
+                <string>script which generates the text for the custom console (see chapter custom console/log scripts for more details)</string>
                </property>
-               <property name="text">
-                <string>custom</string>
-               </property>
-              </widget>
-             </item>
-             <item row="22" column="0">
-              <layout class="QHBoxLayout" name="horizontalLayout_7">
-               <item>
-                <widget class="QToolButton" name="consoleMessageColorButton">
-                 <property name="toolTip">
-                  <string>the color of user messages and timestamps in the console</string>
-                 </property>
-                 <property name="autoFillBackground">
-                  <bool>true</bool>
-                 </property>
-                 <property name="text">
-                  <string>...</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="consoleMessageColorLabel">
-                 <property name="toolTip">
-                  <string>the color of user messages and timestamps in the consoles</string>
-                 </property>
-                 <property name="text">
-                  <string>message color</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item row="20" column="3">
-              <spacer name="verticalSpacer">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>5</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="9" column="1">
-              <spacer name="verticalSpacer_6">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="21" column="1">
-              <layout class="QHBoxLayout" name="horizontalLayout_3">
-               <item>
-                <widget class="QToolButton" name="consoleReceiveColorButton">
-                 <property name="toolTip">
-                  <string>color of the received data in the console</string>
-                 </property>
-                 <property name="autoFillBackground">
-                  <bool>true</bool>
-                 </property>
-                 <property name="text">
-                  <string>...</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="consoleReceiveColorLabel">
-                 <property name="toolTip">
-                  <string>color of the received data in the consoles and text color in the history</string>
-                 </property>
-                 <property name="text">
-                  <string>receive color</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item row="3" column="1">
-              <widget class="QCheckBox" name="consoleShowHexCheckBox">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string>show hexadecimal console</string>
-               </property>
-               <property name="text">
-                <string>hex</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QCheckBox" name="consoleShowAsciiCheckBox">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string>show ascii console</string>
-               </property>
-               <property name="text">
-                <string>ascii</string>
-               </property>
-               <property name="checked">
+               <property name="readOnly">
                 <bool>true</bool>
                </property>
               </widget>
              </item>
-             <item row="0" column="1">
-              <widget class="QCheckBox" name="ShowReceivedCheckBox">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
+             <item row="6" column="7">
+              <widget class="QPushButton" name="consoleSearchScriptPushButton">
                <property name="toolTip">
-                <string>show received data in console</string>
+                <string>add custom console script</string>
                </property>
                <property name="text">
-                <string>receive</string>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
-               <property name="tristate">
-                <bool>false</bool>
+                <string>search</string>
                </property>
               </widget>
              </item>
-             <item row="22" column="1">
-              <layout class="QHBoxLayout" name="horizontalLayout_5">
-               <item>
-                <widget class="QToolButton" name="consoleBackgroundColorButton">
-                 <property name="toolTip">
-                  <string>the background color of the console</string>
-                 </property>
-                 <property name="autoFillBackground">
-                  <bool>true</bool>
-                 </property>
-                 <property name="text">
-                  <string>...</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="consoleBackgroundColorLabel">
-                 <property name="toolTip">
-                  <string>the background color of the consoles and the history</string>
-                 </property>
-                 <property name="text">
-                  <string>back. color</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
+             <item row="7" column="0">
+              <widget class="QCheckBox" name="consoleDebugCustomCheckBox">
+               <property name="toolTip">
+                <string>debug the custom console script</string>
+               </property>
+               <property name="text">
+                <string>debug custom</string>
+               </property>
+              </widget>
              </item>
-             <item row="22" column="2">
-              <widget class="QComboBox" name="consoleFontSizeComboBox">
+             <item row="11" column="2">
+              <widget class="QLineEdit" name="ConsoleUpdateIntervallLineEdit">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>0</height>
-                </size>
                </property>
                <property name="maximumSize">
                 <size>
@@ -2342,14 +1796,11 @@ for TCP clients.</string>
                 </size>
                </property>
                <property name="toolTip">
-                <string>console font size</string>
-               </property>
-               <property name="currentText">
-                <string/>
+                <string>the update intervall of the consoles</string>
                </property>
               </widget>
              </item>
-             <item row="11" column="2" colspan="2">
+             <item row="11" column="3" colspan="2">
               <widget class="QCheckBox" name="consoleTimestampAtByteCheckBox">
                <property name="toolTip">
                 <string>create time stamp at byte</string>
@@ -2359,13 +1810,64 @@ for TCP clients.</string>
                </property>
               </widget>
              </item>
-             <item row="6" column="6">
-              <widget class="QPushButton" name="consoleSearchScriptPushButton">
+             <item row="11" column="5">
+              <widget class="QComboBox" name="consoleTimestampAtByteComboBox">
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>16777215</height>
+                </size>
+               </property>
                <property name="toolTip">
-                <string>add custom console script</string>
+                <string>create time stamp at byte</string>
+               </property>
+              </widget>
+             </item>
+             <item row="10" column="3" colspan="2">
+              <widget class="QCheckBox" name="PrintTimeStampCheckBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>create time stamp after ms</string>
                </property>
                <property name="text">
-                <string>search</string>
+                <string>create time stamp after ms</string>
+               </property>
+               <property name="checked">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="10" column="5">
+              <widget class="QLineEdit" name="PrintTimeStampLineEdit">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="toolTip">
+                <string>create time stamp after ms</string>
+               </property>
+              </widget>
+             </item>
+             <item row="11" column="0">
+              <widget class="QLabel" name="label_5">
+               <property name="toolTip">
+                <string>the update interval of the consoles</string>
+               </property>
+               <property name="text">
+                <string>update interval</string>
                </property>
               </widget>
              </item>
@@ -2388,7 +1890,52 @@ for TCP clients.</string>
                </property>
               </widget>
              </item>
-             <item row="21" column="2" colspan="3">
+             <item row="15" column="2">
+              <widget class="QLineEdit" name="consoleNewLineAfterNumberBytes">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="toolTip">
+                <string>new line after x number of sent/received bytes (0=off)</string>
+               </property>
+               <property name="text">
+                <string>0</string>
+               </property>
+              </widget>
+             </item>
+             <item row="15" column="4">
+              <widget class="QLabel" name="label_16">
+               <property name="toolTip">
+                <string>new line at byte</string>
+               </property>
+               <property name="text">
+                <string>new line at byte</string>
+               </property>
+              </widget>
+             </item>
+             <item row="15" column="5">
+              <widget class="QComboBox" name="consoleNewLineAt">
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="toolTip">
+                <string>new line at byte</string>
+               </property>
+              </widget>
+             </item>
+             <item row="21" column="0">
               <widget class="QFontComboBox" name="consoleFontComboBox">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -2416,40 +1963,17 @@ for TCP clients.</string>
                </property>
               </widget>
              </item>
-             <item row="15" column="3">
-              <widget class="QLabel" name="label_16">
-               <property name="toolTip">
-                <string>new line at byte</string>
-               </property>
-               <property name="text">
-                <string>new line at byte</string>
-               </property>
-              </widget>
-             </item>
-             <item row="15" column="4">
-              <widget class="QComboBox" name="consoleNewLineAt">
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string>new line at byte</string>
-               </property>
-              </widget>
-             </item>
-             <item row="12" column="2" colspan="3">
-              <widget class="QLineEdit" name="ConsoleTimestampFormat">
+             <item row="21" column="3">
+              <widget class="QComboBox" name="consoleFontSizeComboBox">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
                </property>
                <property name="minimumSize">
                 <size>
-                 <width>150</width>
+                 <width>0</width>
                  <height>0</height>
                 </size>
                </property>
@@ -2460,131 +1984,234 @@ for TCP clients.</string>
                 </size>
                </property>
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;time stamp format ('optinal new lines (\n)' date and time format (chapter Time format and Date format in the manual) 'optional new lines (\n)'&lt;/p&gt;&lt;p&gt;Example:&lt;/p&gt;&lt;p&gt;\nyyyy-MM-dd hh:mm:ss.zzz\n&lt;/p&gt;&lt;p&gt;Example without date and with spaces in front of the time stamp:&lt;/p&gt;&lt;p&gt;\n       hh:mm:ss\n&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>console font size</string>
                </property>
+               <property name="currentText" stdset="0">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item row="21" column="2">
+              <widget class="QLabel" name="label_28">
                <property name="text">
-                <string>\nyyyy-MM-dd hh:mm:ss.zzz\n</string>
+                <string>Font Size</string>
                </property>
-              </widget>
-             </item>
-             <item row="15" column="0">
-              <widget class="QLabel" name="label">
-               <property name="toolTip">
-                <string>new line after x number of sent/received bytes (0=off)</string>
-               </property>
-               <property name="text">
-                <string>new line after x bytes</string>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="1" colspan="5">
-              <widget class="DragDropLineEdit" name="consoleScriptLineEdit">
-               <property name="toolTip">
-                <string>script which generates the text for the custom console (see chapter custom console/log scripts for more details)</string>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="16" column="0">
-              <widget class="QLabel" name="label_2">
-               <property name="toolTip">
-                <string>new line after x ms send/receive pause (0=off)</string>
-               </property>
-               <property name="text">
-                <string>new line after ms pause</string>
-               </property>
-              </widget>
-             </item>
-             <item row="16" column="4">
-              <widget class="QComboBox" name="consoleSendOnEnter">
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;this is sent/used for the enter key (console, message dialog, main window send area and ascii sequence in the send window)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-              </widget>
-             </item>
-             <item row="16" column="1">
-              <widget class="QLineEdit" name="consoleNewLineAfterPause">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string>new line after x ms send/receive pause (0=off)</string>
-               </property>
-               <property name="text">
-                <string>0</string>
-               </property>
-              </widget>
-             </item>
-             <item row="15" column="1">
-              <widget class="QLineEdit" name="consoleNewLineAfterNumberBytes">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string>new line after x number of sent/received bytes (0=off)</string>
-               </property>
-               <property name="text">
-                <string>0</string>
-               </property>
-              </widget>
-             </item>
-             <item row="16" column="3">
-              <widget class="QLabel" name="label_18">
-               <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;this is sent/used for the enter key (console, message dialog, main window send area and ascii sequence in the send window)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-               <property name="text">
-                <string>send on enter key</string>
-               </property>
-              </widget>
-             </item>
-             <item row="7" column="0">
-              <widget class="QCheckBox" name="consoleDebugCustomCheckBox">
-               <property name="toolTip">
-                <string>debug the custom console script</string>
-               </property>
-               <property name="text">
-                <string>debug custom</string>
-               </property>
-              </widget>
-             </item>
-             <item row="7" column="6">
-              <widget class="QPushButton" name="consoleEditScriptPushButton">
-               <property name="toolTip">
-                <string>edit custom console script</string>
-               </property>
-               <property name="text">
-                <string>edit</string>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
                </property>
               </widget>
              </item>
             </layout>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabColors">
+      <attribute name="title">
+       <string>Colors</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_6">
+       <item>
+        <widget class="QScrollArea" name="scrollArea_7">
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents_7">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>831</width>
+            <height>412</height>
+           </rect>
+          </property>
+          <layout class="QFormLayout" name="formLayout">
+           <item row="0" column="0">
+            <widget class="QToolButton" name="btnColorAscii">
+             <property name="autoFillBackground">
+              <bool>true</bool>
+             </property>
+             <property name="styleSheet">
+              <string notr="true"/>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="toolButtonStyle">
+              <enum>Qt::ToolButtonFollowStyle</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="lblColorAscii">
+             <property name="text">
+              <string>Color for ASCII data in mixed console</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QToolButton" name="btnColorHex">
+             <property name="autoFillBackground">
+              <bool>true</bool>
+             </property>
+             <property name="styleSheet">
+              <string notr="true"/>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="toolButtonStyle">
+              <enum>Qt::ToolButtonFollowStyle</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="lblColorAscii_5">
+             <property name="text">
+              <string>Color for HEXADECIMAL data in mixed console</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QToolButton" name="btnColorDec">
+             <property name="autoFillBackground">
+              <bool>true</bool>
+             </property>
+             <property name="styleSheet">
+              <string notr="true"/>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="toolButtonStyle">
+              <enum>Qt::ToolButtonFollowStyle</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QToolButton" name="btnColorBin">
+             <property name="autoFillBackground">
+              <bool>true</bool>
+             </property>
+             <property name="styleSheet">
+              <string notr="true"/>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="toolButtonStyle">
+              <enum>Qt::ToolButtonFollowStyle</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QLabel" name="lblColorAscii_6">
+             <property name="text">
+              <string>Color for BINARY data in mixed console</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QToolButton" name="consoleSendColorButton">
+             <property name="toolTip">
+              <string>color of the sent data in the console</string>
+             </property>
+             <property name="autoFillBackground">
+              <bool>true</bool>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QLabel" name="consoleSendColorLabel">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="text">
+              <string>Color of the sent data in the consoles</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0">
+            <widget class="QToolButton" name="consoleReceiveColorButton">
+             <property name="toolTip">
+              <string>color of the received data in the console</string>
+             </property>
+             <property name="autoFillBackground">
+              <bool>true</bool>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1">
+            <widget class="QLabel" name="consoleReceiveColorLabel">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="text">
+              <string>Color of the received data in the consoles and text color in the history</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QToolButton" name="consoleBackgroundColorButton">
+             <property name="toolTip">
+              <string>the background color of the console</string>
+             </property>
+             <property name="autoFillBackground">
+              <bool>true</bool>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="1">
+            <widget class="QLabel" name="consoleBackgroundColorLabel">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="text">
+              <string>Background color of the consoles and the history</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="0">
+            <widget class="QToolButton" name="consoleMessageColorButton">
+             <property name="toolTip">
+              <string>the color of user messages and timestamps in the console</string>
+             </property>
+             <property name="autoFillBackground">
+              <bool>true</bool>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="1">
+            <widget class="QLabel" name="consoleMessageColorLabel">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="text">
+              <string>Color of user messages and timestamps in the consoles</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QLabel" name="lblColorAscii_2">
+             <property name="text">
+              <string>Color for DECIMAL data in mixed console</string>
+             </property>
+            </widget>
            </item>
           </layout>
          </widget>
@@ -2599,70 +2226,6 @@ for TCP clients.</string>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
         <widget class="QScrollArea" name="scrollArea_2">
-         <property name="palette">
-          <palette>
-           <active>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </active>
-           <inactive>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </inactive>
-           <disabled>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-            <colorrole role="Window">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>255</red>
-               <green>255</green>
-               <blue>255</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </disabled>
-          </palette>
-         </property>
          <property name="widgetResizable">
           <bool>true</bool>
          </property>
@@ -2670,9 +2233,9 @@ for TCP clients.</string>
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>-110</y>
-            <width>718</width>
-            <height>457</height>
+            <y>0</y>
+            <width>780</width>
+            <height>629</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_2">
@@ -3365,6 +2928,171 @@ Note: The reopen buton in the main window is only visible if this option is sele
        </item>
       </layout>
      </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>general</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_8">
+      <property name="rightMargin">
+       <number>12</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_25">
+        <property name="statusTip">
+         <string>the current interface</string>
+        </property>
+        <property name="text">
+         <string>current interface</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="connectionTypeComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="statusTip">
+         <string>the current interface</string>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+        <item>
+         <property name="text">
+          <string>serial port</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>socket</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>spi master</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>pcan</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <spacer name="horizontalSpacer_8">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="3" column="6">
+       <widget class="QPushButton" name="closeButton">
+        <property name="text">
+         <string>Close</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="6">
+       <widget class="QPushButton" name="searchScriptEditorPushButton">
+        <property name="text">
+         <string>search</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLabel" name="label_26">
+        <property name="toolTip">
+         <string>endianess of the connected device (is used to interpret the decimals
+in the log, the decimal console and the send window)</string>
+        </property>
+        <property name="text">
+         <string>endianness</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="5">
+       <widget class="DragDropLineEdit" name="scriptEditorPathLineEdit">
+        <property name="toolTip">
+         <string>path to the external script editor</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_24">
+        <property name="text">
+         <string>script editor</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QComboBox" name="endianessComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>endianess of the connected device (is used to interpret the decimals
+in the log, the decimal console and the send window)</string>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+        <item>
+         <property name="text">
+          <string>little-endian</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>big-endian</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
- Backgroundcolor for mixed console can be defined individually for
  each type (ascii, decimal, hex, binary)
- Color settings got an own tab in settings dialog.
- Backgroundcolor on settings dialog taken from window theme, since the
  white background did not play well with a dark themed user interface.
- Set whole background of color button in selected color to make selected
  color more visual.
- Connected all color buttons with a signalmapper to the same function
  to show color picker dialog.