### PR TITLE
Change font size with Ctrl + mouse wheel

### DIFF
--- a/ScriptCommunicator/mainwindow.cpp
+++ b/ScriptCommunicator/mainwindow.cpp
@@ -117,6 +117,39 @@ void SendConsole::keyPressEvent(QKeyEvent *event)
 }
 
 /**
+ * Use Ctrl + mouse wheel to increase/decrease font size in consoles.
+ */
+void SendConsole::wheelEvent(QWheelEvent *event)
+{
+    SettingsDialog *m_settingsDialog = m_mainWindow->getSettingsDialog();
+    m_settingsDialog->updateSettings();
+    Settings currentSettings = *m_settingsDialog->settings();
+    QString currentConsoleFontSize = currentSettings.stringConsoleFontSize;
+    auto fontSize = currentConsoleFontSize.toInt();
+
+    if (event->modifiers() == Qt::ControlModifier) {
+        QPoint numDegrees = event->angleDelta();
+        if (!numDegrees.isNull()) {
+            if (numDegrees.y() > 0) {
+                // scroll up zooms in
+                if (++fontSize > currentSettings.maxFontSize)
+                    fontSize = currentSettings.maxFontSize;
+            } else {
+                // scroll down zooms out
+                if (--fontSize < currentSettings.minFontSize)
+                    fontSize = currentSettings.minFontSize;
+            }
+        }
+
+        currentSettings.stringConsoleFontSize = QString::number(fontSize);
+        m_settingsDialog->setAllSettingsSlot(currentSettings);
+    }
+
+    // forward event to parent for normal scrolling
+    QTextEdit::wheelEvent(event);
+}
+
+/**
  * Constructor.
  * @param scripts
  *      The command-line scripts.

--- a/ScriptCommunicator/mainwindow.h
+++ b/ScriptCommunicator/mainwindow.h
@@ -110,6 +110,9 @@ public:
     ///The user has pressed a key.
     void keyPressEvent(QKeyEvent *event);
 
+    ///The user scrolled within console.
+    void wheelEvent(QWheelEvent *event);
+
     ///Sets m_mainWindow.
     void setMainWindow(MainWindow* mainWindow)
     {
@@ -396,7 +399,7 @@ private slots:
     ///Slot function for the connect button.
     void toggleConnectionSlot(bool connectionStatus);
 
-	///Slot function for the connect button.
+    ///Slot function for the connect button.
     void connectButtonSlot(void);
 
     ///Slot function for the show sending window button.

--- a/ScriptCommunicator/mainwindowHandleData.cpp
+++ b/ScriptCommunicator/mainwindowHandleData.cpp
@@ -123,11 +123,11 @@ void MainWindowHandleData::updateConsoleAndLog(void)
             html += QString("pt;color:#" + settings->consoleReceiveColor+ ";\">");
             consoleString = html + consoleString + QString("</span>");
 
-            bool wasEmpty = (m_userInterface->ReceiveTextEditCustom->document()->characterCount() <= 1) ? true : false;
             m_mainWindow->appendConsoleStringToConsole(&consoleString, m_userInterface->ReceiveTextEditCustom);
             m_customConsoleStrings.clear();
             m_numberOfBytesInCustomConsoleStrings = 0;
-            if(wasEmpty)
+
+            if(m_userInterface->ReceiveTextEditCustom->document()->characterCount() <= 1)
             {
                 //Force the custom console to render the content.
                 QRect rect = MainWindow::windowPositionAndSize(m_mainWindow);
@@ -140,7 +140,8 @@ void MainWindowHandleData::updateConsoleAndLog(void)
             }
 
             while((m_numberOfBytesInCustomConsoleStoredStrings > (settings->maxCharsInConsole * 2)) && m_customConsoleStoredStrings.length() > 1)
-            {//Limit the number of bytes in m_customConsoleStoredStrings.
+            {
+                //Limit the number of bytes in m_customConsoleStoredStrings.
                 m_numberOfBytesInCustomConsoleStoredStrings -= m_customConsoleStoredStrings.first().length();
                 m_customConsoleStoredStrings.removeFirst();
             }

--- a/ScriptCommunicator/settingsdialog.cpp
+++ b/ScriptCommunicator/settingsdialog.cpp
@@ -68,11 +68,11 @@ SettingsDialog::SettingsDialog(QAction *actionLockScrolling) :
 
     m_pcanInterface = new PCANBasicClass(this);
 
-
     m_userInterface->baudRateBox->setInsertPolicy(QComboBox::NoInsert);
 
     QStringList listFontSize;
-    listFontSize << "4" << "5" << "6" << "7" << "8" << "9" << "10" << "11" << "12" << "13" << "14" << "15" << "16";
+    for (int fs = settings()->minFontSize; fs <= settings()->maxFontSize; fs++)
+        listFontSize.append(QString::number(fs));
     m_userInterface->consoleFontSizeComboBox->addItems(listFontSize);
     m_userInterface->consoleFontSizeComboBox->setCurrentText("10");
 

--- a/ScriptCommunicator/settingsdialog.h
+++ b/ScriptCommunicator/settingsdialog.h
@@ -205,6 +205,9 @@ struct Settings
     ///The consoles font size.
     QString stringConsoleFontSize;
 
+    static const int minFontSize = 4;
+    static const int maxFontSize = 20;
+
     ///The consoles update interval.
     quint32 updateIntervalConsole;
 


### PR DESCRIPTION
Scrolling the mouse wheel while holding down Ctrl key in any of the console text fields increases (scroll up) or decreases (scroll down) the font.