### PR TITLE
Feature/generic crc

### DIFF
--- a/ScriptCommunicator/crc.cpp
+++ b/ScriptCommunicator/crc.cpp
@@ -22,7 +22,7 @@
 **  Website/Contact: http://sourceforge.net/projects/scriptcommunicator/  **
 ****************************************************************************/
 
-#include <limits.h>
+#include <climits>
 #include "crc.h"
 
 

--- a/ScriptCommunicator/crc.cpp
+++ b/ScriptCommunicator/crc.cpp
@@ -22,6 +22,7 @@
 **  Website/Contact: http://sourceforge.net/projects/scriptcommunicator/  **
 ****************************************************************************/
 
+#include <limits.h>
 #include "crc.h"
 
 
@@ -47,13 +48,12 @@ quint8 CRC::calculateCrc8(const QVector<unsigned char> data,
                           const unsigned char polynomial, const unsigned char startValue)
 {
     quint8 crc = startValue;
-    const qint32 BITS_PER_BYTE = 8;
 	
 	for( auto val: data )
 	{
 		crc = crc ^ val;
 		
-        for( qint32 i = 0; i < BITS_PER_BYTE; ++i )
+        for( qint32 i = 0; i < CHAR_BIT; ++i )
 		{
 			if( (crc & 0x80) != 0 )
 			{


### PR DESCRIPTION
Fixed macro to get number of bits in a byte in a portable way using correct C++ header. Now we can get the number of bits in a byte in a portable way because GCC does that for us if we use correct header definitions. I think it is better than hardcoding a value inside the source code.

See http://www.cplusplus.com/reference/climits/ and http://stackoverflow.com/questions/3200954/what-is-char-bit

Thank you.