### PR TITLE
Include QPainterPath in color_wheel

### DIFF
--- a/ScriptCommunicator/colorWidgets/color_wheel.cpp
+++ b/ScriptCommunicator/colorWidgets/color_wheel.cpp
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QPainterPath>
 #include <QLineF>
 #include <QDragEnterEvent>
 #include <QMimeData>


### PR DESCRIPTION
Required for compilation with QT 5.15 and higher, otherwise it fails with:
```
colorWidgets/color_wheel.cpp:345:22: error: aggregate 'QPainterPath clip' has incomplete type and cannot be defined
  345 |         QPainterPath clip;
      |                      ^~~~
```

Similar to https://github.com/DreamSourceLab/DSView/issues/317