### PR TITLE
Color-changing labels now defaults to darkGray

### DIFF
--- a/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/ESPConsole.js
+++ b/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/ESPConsole.js
@@ -37,7 +37,7 @@ function mainWindowClearConsoleClicked()
 {
 	UI_TextEdit1.clear();
 	UI_label_backtrace.setText("Decoding backtrace for ESP Project:");
-	UI_label_backtrace.setWindowTextColor("");	// Use "" as reset to default instead of "black", which does not work well in dark style
+	UI_label_backtrace.setWindowTextColor("darkGray");	// Reasonable default that works on dark and light themes
 }
 
 //Reads the global console settings (settings dialog) and adjusts the utf8 console to it.
@@ -286,3 +286,4 @@ settingsTimer.start(2000);
 
 // Load settings
 loadUiSettings();
+UI_label_backtrace.setWindowTextColor("darkGray");	// Reasonable default that works on dark and light themes

--- a/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/README.md
+++ b/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/README.md
@@ -44,5 +44,6 @@ If you, for example, run the console on different system without build tools, yo
 
 #### TODO:
 
+- Possible logical error with decoder autodisable when incorrect input file/s are selected
 - Add tooltips and/or link to this readme
 

--- a/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/backtraceSettings.js
+++ b/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/backtraceSettings.js
@@ -51,10 +51,10 @@ function cleanAll()
 	if(UI_chkBox_autodetectTools.isChecked() ) {
 		UI_lnEd_pathAddr2Line.setText("");
 		UI_label_verAddr2Line.setText("");
-		UI_label_verAddr2Line.setWindowTextColor("");
+		UI_label_verAddr2Line.setWindowTextColor("darkGray");	// Reasonable default that works on dark and light themes
 		UI_lnEd_pathReadElf.setText("");
 		UI_label_verReadelf.setText("");
-		UI_label_verReadelf.setWindowTextColor("");
+		UI_label_verReadelf.setWindowTextColor("darkGray");		// Reasonable default that works on dark and light themes
 	}
 	cleanFwInfo();
 }
@@ -72,7 +72,7 @@ function addr2lineVersionUpdate()
 		}
 		else {		// OK
 			UI_label_verAddr2Line.setText( (ret.stdOut).split("\n")[0] );	// First Line
-			UI_label_verAddr2Line.setWindowTextColor("");
+			UI_label_verAddr2Line.setWindowTextColor("darkGray");	// Reasonable default that works on dark and light themes
 		}
 	}
 }
@@ -90,7 +90,7 @@ function readelfVersionUpdate()
 		}
 		else {		// OK
 			UI_label_verReadelf.setText( (ret.stdOut).split("\n")[0] );		// First Line
-			UI_label_verReadelf.setWindowTextColor("");
+			UI_label_verReadelf.setWindowTextColor("darkGray");	// Reasonable default that works on dark and light themes
 		}
 	}
 }


### PR DESCRIPTION
Change default color of labels with variable color to darkGray which works reasonably well on both dark and light system themes