### PR TITLE
Some improvements on ESPConsole v1.1

### DIFF
--- a/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/ESPConsole.js
+++ b/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/ESPConsole.js
@@ -7,7 +7,7 @@ See README.md for more details.
 Requres ScriptCommunicator v6+ (getUserGenericConfigFolder())
 ****************************************************************************************/
 
-var VERSION_INFO = "ESP Console v1.1 (24.03.2023)";
+var VERSION_INFO = "ESP Console v1.1 (26.03.2023)";
 
 // Load additional scripts and UI
 scriptThread.loadScript("runProcessAsync.js");
@@ -277,7 +277,6 @@ function dataReceivedSlot(data)
 
 // Connect Signals
 UI_btnBacktraceSettings.clickedSignal.connect(showSettingsDialog);
-
 
 //The console settings.
 var g_settings = scriptThread.getConsoleSettings();

--- a/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/README.md
+++ b/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/README.md
@@ -1,4 +1,4 @@
-# ESP32 Console
+# ESP Console
 
 This script is based on ANSI Color Console but also adds an option to decode ESP32 backtrace if system crashes. 
 
@@ -8,59 +8,70 @@ Without it you would have to use `idf.py monitor` or other tools separately to d
 
 Instead, when backtrace is detected, we can simply call, for example, `xtensa-esp32-elf-addr2line -pfiaC -e build/PROJECT.elf ADDRESS` command directly from this script and see the decoded messages in console without having to switch to other tools. 
 
-Main window's **Clear** button is not only used for clearing the console, but also resets status of "Backrtace detected!" information and refreshes current project firmware info.
-
-## Requirements
+## Usage
 
 ### Option 1: No backtrace (default)
 
 Of course you can use this as serial terminal with no backtrace decoding in which case this script will take care of removing ANSI color sequences (for example those `[0;32m` at the beginning of the lines) and colorize your ESP log output accordingly.
 
-
 ### Option 2: Autodetect tools (recommended)
 
-If you have correctly set up and working ESP-IDF Cmake build environment the only requirement would be to select project **ELF file that is running on your ESP MCU**. You should find this file in `/build` subfolder of your IDF project.  
-With default config it should be the only `.elf` file in build folder. Autodetect then finds correct xtensa tools that will be used for backtrace decoding by parsing contents of `CmakeCache.txt` from the same folder.
+If you have correctly set up and working ESP-IDF Cmake build environment the only requirement would be to select project **ELF file that is running on your ESP MCU**. You should find this file in `/build` subfolder of your IDF project. 
+With default config it should be the only `.elf` file in build folder. * **Autodetect Tools from ELF** * then finds correct xtensa tools that will be used for backtrace decoding by parsing contents of `CmakeCache.txt` from the same folder.
 
 #### Requires:
 - Completely set-up and working ESP-IDF Cmake build environment
 - Project output `.elf` file and `CmakeCache.txt` in same folder
-- Project successfully built, same build version running on ESP MCU
-
+- Project successfully built, same build version running on ESP MCU 
 
 ### Option 3: Manual tools selection (advanced)
 
-If you, for example, run the console on different system without build tools or your IDF project is using **legacy make**, you can still decode the backtraces. In this case you have to find correct decoding tools manually, which may be a bit complicated as there are multiple versions of the tools, each for specific target and ESP-IDF version. 
+If you, for example, run the console on different system without build tools or your IDF project is using **legacy make**, you can still decode the backtraces. In this case you can * **uncheck Autodetect Tools from ELF** * and then find correct decoding tools manually. That may be a bit complicated as there are multiple versions of the tools, each for specific target and ESP-IDF version. 
 
 #### Requires:
 - Project output `.elf` file
 - `elf-addr2line` executable to decode backtraces (*xtensa-esp32-elf-addr2line.exe* for example)
 - Optional: `elf-readelf` executable to decode firmware information (*xtensa-esp32-elf-readelf.exe* for example) 
-- Project successfully built, same build version running on ESP MCU
+- Project successfully built, same build version running on ESP MCU 
+
+### Other functions 
+
+- Main window's **Clear** button is not only used for clearing the console, but also resets status of *'Backtrace detected!'* info label and refreshes current project firmware info.
+- You can also use functionality on *'Manual Address Decode'* tab in settings dialog to decode selected address/es manually. Works for single address or whole block - each address starting with 0x gets decoded.
 
 ----
 
 ## Notes
 
+To issue bug or feature request for the ESP Console script your best bet would be to do it in script author's fork directly: [https://github.com/mmrein/ScriptCommunicator_serial-terminal/tree/ESPConsole](https://github.com/mmrein/ScriptCommunicator_serial-terminal/tree/ESPConsole).  
+Alternatively you can try original ScriptCommunicator repo: [https://github.com/szieke/ScriptCommunicator_serial-terminal/tree/ESPConsole](https://github.com/szieke/ScriptCommunicator_serial-terminal/tree/ESPConsole).
+
 - Tested on Ubuntu 20 with autodetect and manual, IDF v4.4.1, v4.4.4, v5.0.1
 - Tested on Windows with manual tools selection only, IDF tools v4.4.4
 - Backtrace decoding of project built with *legacy make* not tested
 
+#### Notes on markdown formatters:
+
+> Although `QTextEdit` class does support markdown formatting, `setMarkdown()` function is not implemented in ScriptCommunicator. Adding it should not be very difficult, but using external libraries may offer more variability and their output may even look better than current QT markdown formatter.  
+
+> For basic MD-to-HTML conversion, results using [marked](https://github.com/markedjs/marked) library were visually not too different than using [snarkdown](https://github.com/bpmn-io/snarkdown) lib, but sizes differ significantly. While **marked** with its 50kB of compacted inline text is already quite small, it would still almost double the size of ESPConsole script. **Snarkdown** with its minimalist approach is 5kB while still in human-readable form, which fits much better.
+
 ### Changelog
 
-#### v1.1 24.03.2023
+#### ESP Console v1.1 (26.03.2023)
 
 - Firmware info can now be refreshed by clicking **Clear** button in main window.
-- Added internal "Backtrace:" string search to singalize the backtrace was detected even if it could not be decoded.
-- Added checkbox to Show invalid results too (decoded backtrace result is '?? ??:0' or '??:?')
+- Added internal "Backtrace:" string search to signalize the backtrace was detected even if it could not be decoded.
+- Added checkbox to Show invalid results too (decoded backtrace result is '`?? ??:0`' or '`??:?`')
+- Added *Manual Address Decode* tab where user can write selected address(es) and decode them directly. 
+- Added *Readme* tab which shows this file. Snarkdown JS source is used for markdown formatting. 
 - Version info label added
 
-#### v1.0 17.03.2023
+#### ESP Console v1.0 (17.03.2023)
 
 - Initial release
 
 ### TODO:
 
-- Add manual address decode option 
-- Add tooltips and/or link to this readme
+- Maybe some tooltips here and there
 

--- a/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/backtraceSettings.js
+++ b/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/backtraceSettings.js
@@ -1,5 +1,6 @@
 ﻿/*************************************************************************
-This script file contains function for script settings data loading and saving
+This script file contains functions for script settings data loading and saving 
+and other features that are used in Backtrace Settings dialog window.
 
   We need to find ESP project build path (ideally by selscting project's output .elf) 
   from where we can parse  other necessary info, like project name and exact 
@@ -12,7 +13,6 @@ Requres ScriptCommunicator v6+ (getUserGenericConfigFolder())
 /* ====    Load additional scripts and UI    ==== */
 scriptThread.loadUserInterfaceFile("./backtraceSettings.ui", true, false);
 
-
 /* ====    Global variables    ==== */
 var g_settingsFolder = scriptThread.getUserGenericConfigFolder() + "/SCScripts/";
 var g_settingsFileName = g_settingsFolder + "ESPConsole.ini";
@@ -24,6 +24,8 @@ UI_pbOk.clickedSignal.connect(UI_pbOk, closeSettingsDialog);
 UI_pbCancel.clickedSignal.connect(UI_pbCancel, closeSettingsDialog);
 UI_pb_selectAddr2Line.clickedSignal.connect(UI_pb_selectAddr2Line, clickedOpenToolsFile);
 UI_pb_selectReadElf.clickedSignal.connect(UI_pb_selectReadElf, clickedOpenToolsFile);
+UI_pb_manualAddrDecode.clickedSignal.connect(clickedManualAddrDecode);
+UI_pb_Readme.clickedSignal.connect(openReadme);
 // Checkbox
 UI_chkBox_backtraceDecode.clickedSignal.connect(clickedDecode);
 UI_chkBox_autodetectTools.clickedSignal.connect(clickedAutodetect);
@@ -31,9 +33,87 @@ UI_chkBox_autodetectTools.clickedSignal.connect(clickedAutodetect);
 UI_comBox_projecElfFile.currentTextChangedSignal.connect(parseFwFileInfo);
 
 /* ====    Set info text     ==== */
+var readmeTab = UI_settingsTab.removeTab(2);	// Remove Readme tab by default, can be opened by clicking on Readme button
 UI_label_EspConsoleVersion.setText(VERSION_INFO);
 
 /* ====    Functions     ==== */
+
+/* Async timer callback that waits for readme text to show up in text edit after
+	it was loaded and then it can autoscroll to beginning of text.
+ */
+function readmeRefresh() {
+	UI_txtEd_Help.show();	// may not be necessary
+	var tout = 3000;	
+	while( (UI_txtEd_Help.verticalScrollBarValue() == 0) && (tout > 0) ) {
+		scriptThread.sleep(10);
+		tout -= 10;		// Failsafe tout countdown
+	}
+	UI_txtEd_Help.verticalScrollBarSetValue(0);	// Now we can finally scroll to top
+}
+
+/* Add readme tab and load text after clicking the Readme button the first time */
+function openReadme() 
+{
+	if(readmeTab != null) 
+	{
+		UI_settingsTab.insertTab(readmeTab, 2);				// Insert tab which was removed during script init
+		UI_settingsTab.setCurrentIndex(2);					// Set it active too
+		scriptThread.loadScript("snarkdown.js");			// Load snarkdown lib 
+		var readmeMd = scriptThread.readFile("README.md");	// Load markdown text from file
+		var readmeHtml = snarkdown(readmeMd);				// Parse MD using snarkdown to HTML
+		UI_txtEd_Help.insertHtml(readmeHtml);				// Insert resulting HTML to text edit
+		readmeTab = null;						// Clear the ID variable to diable this part of code to rerun
+		/* Now the problem is if we want to autoscroll to top after load. Showing the resulting text currently
+			takes 300ms and will change depending on content. That means we can not just show() and set
+			verticalScrollBarSetValue(0) now as there is nothing to show and set - we need to wait instead.
+		   Using sleep would be quite simple, but that is barely a workaround. It also does not seem to work 
+			as expected while we are still in this button callback. UI_txtEd_Help.textChangedSignal.connect() 
+			does not help either.
+		   What seems to be working best is using one shot timer so we can exit this callback and then 
+			wait for loaded text in that timer's callback. 
+		*/
+		var readmeLoad = scriptThread.createTimer();
+		readmeLoad.timeoutSignal.connect(readmeRefresh);
+		readmeLoad.setSingleShot(true);
+		readmeLoad.start(10);
+	}
+}
+
+/* Find and decode backtrace addresses provided in text field input
+Example: Backtrace: 0x40081f06:0x3fff0fa0 0x4008ac4d:0x3fff0fc0 0x4008ec3a:0x3fff0fe0 0x4008cb1f:0x3fff1060 0x4008ad48:0x3fff1080 0x4008acfa:0x007b1948 |<-CORRUPTED 
+ */
+function clickedManualAddrDecode()
+{
+	var backtraceString = UI_txtEd_manualAddr.toPlainText();
+	UI_txtEd_manualAddrResult.setPlainText("");
+	
+	// Create arrray of strings for backtrace addresses:
+	var addrs = Array();	
+	// Safest option would be to search for every '0x' character combination and take folowing 8 characters
+	var idx = backtraceString.indexOf("0x", 0);	// from start
+	// If 0x was found at all:
+	while( idx >= 0 ) 
+	{
+		// In this case we can simply add anything up to 21 characters and try decoding it
+		addrs.push( backtraceString.slice(idx, idx+21) ); 	// Add address:address to array of strings
+		idx = backtraceString.indexOf("0x", idx+10);		// Start next search after previous end
+	}
+
+	var program = UI_lnEd_pathAddr2Line.text();	
+	var elfFile = UI_comBox_projecElfFile.currentText();
+	// Run xtensa addr2line command for every address: xtensa-esp32-elf-addr2line -pfiaC -e build/PROJECT.elf ADDRESS
+	for(var i = 0; i < addrs.length; i++)
+	{
+		var arguments = Array("-pfiaC", "-e", ""+elfFile+"", addrs[i]);
+		var ret = runProcessAsync(program, arguments, 1000, 1000, "");		
+		if(ret.exitCode != 0) { 	// Error
+			UI_txtEd_manualAddrResult.setPlainText( UI_txtEd_manualAddrResult.toPlainText() + ret.stdErr );
+		}
+		else {
+			UI_txtEd_manualAddrResult.setPlainText( UI_txtEd_manualAddrResult.toPlainText() + ret.stdOut );
+		}
+	}
+}
 
 /* Empty firmware info if requirements not satisfied */
 function cleanFwInfo() 
@@ -306,20 +386,22 @@ function closeSettingsDialog()
 function clickedDecode ()
 {
 	if(UI_chkBox_backtraceDecode.isChecked()) {
-		UI_lnEd_projectLoaded.setEnabled(true);	// Main window tab
-		UI_label_backtrace.setEnabled(true);	// Main window tab
+		UI_lnEd_projectLoaded.setEnabled(true);		// Main window tab
+		UI_label_backtrace.setEnabled(true);		// Main window tab
 		UI_grpBox_FWInfo.setEnabled(true);
 		UI_lnEd_pathAddr2Line.setEnabled(true);
 		UI_lnEd_pathReadElf.setEnabled(true);
 		UI_chkBox_autodetectTools.setEnabled(true);
+		UI_pb_manualAddrDecode.setEnabled(true);	// Manual address decode tab			
 	}
 	else {
-		UI_lnEd_projectLoaded.setEnabled(false);// Main window tab
-		UI_label_backtrace.setEnabled(false);	// Main window tab
+		UI_lnEd_projectLoaded.setEnabled(false);	// Main window tab
+		UI_label_backtrace.setEnabled(false);		// Main window tab
 		UI_grpBox_FWInfo.setEnabled(false);
 		UI_lnEd_pathAddr2Line.setEnabled(false);
 		UI_lnEd_pathReadElf.setEnabled(false);
 		UI_chkBox_autodetectTools.setEnabled(false);
+		UI_pb_manualAddrDecode.setEnabled(false);	// Manual address decode tab	
 	}
 }
 

--- a/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/backtraceSettings.ui
+++ b/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/backtraceSettings.ui
@@ -1,671 +1,877 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>settingsDialog</class>
- <widget class="QDialog" name="settingsDialog">
+ <widget class="QMainWindow" name="settingsDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>706</width>
-    <height>441</height>
+    <width>799</width>
+    <height>480</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>ESP-IDF Backtrace Settings</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="2">
-    <widget class="QPushButton" name="pbOk">
-     <property name="text">
-      <string>OK</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="3">
-    <widget class="QGroupBox" name="grpBox_Tools">
-     <property name="minimumSize">
-      <size>
-       <width>500</width>
-       <height>171</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>Decoding Tools</string>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>101</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Addr2Line Path:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>101</width>
-          <height>19</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Addr2Line Ver:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QLabel" name="label_verReadelf">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" colspan="2">
-       <widget class="QLineEdit" name="lnEd_pathAddr2Line">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>300</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="frame">
-         <bool>true</bool>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>101</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>ReadElf Path:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="2">
-       <widget class="QPushButton" name="pb_selectReadElf">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>131</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Select ReadElf</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QPushButton" name="pb_selectAddr2Line">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>131</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Select Addr2Line</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1" colspan="2">
-       <widget class="QLineEdit" name="lnEd_pathReadElf">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>300</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="frame">
-         <bool>true</bool>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="label_verAddr2Line">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>101</width>
-          <height>19</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Readelf Ver:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="chkBox_autodetectTools">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>21</height>
-         </size>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
-        </property>
-        <property name="text">
-         <string>Autodetect Tools from ELF</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="3">
-    <widget class="QGroupBox" name="grpBox_FWInfo">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>101</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>Firmware Info</string>
-     </property>
-     <property name="flat">
-      <bool>false</bool>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_14">
-        <property name="text">
-         <string>Project Name:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QLabel" name="label_10">
-        <property name="text">
-         <string>Build Date:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="4">
-       <widget class="QLabel" name="label_11">
-        <property name="text">
-         <string>Build Time:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_18">
-        <property name="text">
-         <string>Project Version:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="5">
-       <widget class="QLineEdit" name="lnEd_FwBuildTime">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>71</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>-</string>
-        </property>
-        <property name="maxLength">
-         <number>32</number>
-        </property>
-        <property name="frame">
-         <bool>true</bool>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-        <property name="readOnly">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLineEdit" name="lnEd_FwAppVer">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>81</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>-</string>
-        </property>
-        <property name="maxLength">
-         <number>32</number>
-        </property>
-        <property name="frame">
-         <bool>true</bool>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="3">
-       <widget class="QLineEdit" name="lnEd_FwBuildDate">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>71</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>-</string>
-        </property>
-        <property name="maxLength">
-         <number>32</number>
-        </property>
-        <property name="frame">
-         <bool>true</bool>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-        <property name="readOnly">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="lnEd_FwName">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>181</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>-</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Target:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="QLineEdit" name="lnEd_target">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>61</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="frame">
-         <bool>true</bool>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="4">
-       <widget class="QLabel" name="label_9">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>ESP-IDF Version:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="5">
-       <widget class="QLineEdit" name="lnEd_FwIDFVer">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>81</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>-</string>
-        </property>
-        <property name="maxLength">
-         <number>32</number>
-        </property>
-        <property name="frame">
-         <bool>true</bool>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QPushButton" name="pbCancel">
-     <property name="text">
-      <string>Cancel</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_EspConsoleVersion">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>ESP Console v1.1</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="3">
-    <widget class="QGroupBox" name="grpBox_Decode">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>95</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>Decode form ELF File</string>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="chkBox_backtraceDecode">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>21</height>
-         </size>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
-        </property>
-        <property name="text">
-         <string>Enable Backtrace Decoder</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="pb_openProjectElf">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>131</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Select Project ELF</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QComboBox" name="comBox_projecElfFile">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>400</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="editable">
-         <bool>false</bool>
-        </property>
-        <property name="maxVisibleItems">
-         <number>10</number>
-        </property>
-        <property name="insertPolicy">
-         <enum>QComboBox::InsertAtTop</enum>
-        </property>
-        <property name="minimumContentsLength">
-         <number>2</number>
-        </property>
-        <property name="frame">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="chkBox_invalidResultsEnable">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>21</height>
-         </size>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
-        </property>
-        <property name="text">
-         <string>Show invalid results too ('?? ??:0', '??:?')</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-  </layout>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="3" column="1">
+     <widget class="QLabel" name="label_EspConsoleVersion">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="text">
+       <string>ESP Console v1.0.0</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="3">
+     <widget class="QPushButton" name="pbCancel">
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>25</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Cancel</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0" colspan="5">
+     <widget class="QGroupBox" name="grpBox_FWInfo">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>101</height>
+       </size>
+      </property>
+      <property name="title">
+       <string>Firmware Info</string>
+      </property>
+      <property name="flat">
+       <bool>false</bool>
+      </property>
+      <property name="checkable">
+       <bool>false</bool>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_14">
+         <property name="text">
+          <string>Project Name:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QLabel" name="label_10">
+         <property name="text">
+          <string>Build Date:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="4">
+        <widget class="QLabel" name="label_11">
+         <property name="text">
+          <string>Build Time:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_18">
+         <property name="text">
+          <string>Project Version:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="5">
+        <widget class="QLineEdit" name="lnEd_FwBuildTime">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>71</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>-</string>
+         </property>
+         <property name="maxLength">
+          <number>32</number>
+         </property>
+         <property name="frame">
+          <bool>true</bool>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="readOnly">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLineEdit" name="lnEd_FwAppVer">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>81</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>-</string>
+         </property>
+         <property name="maxLength">
+          <number>32</number>
+         </property>
+         <property name="frame">
+          <bool>true</bool>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="3">
+        <widget class="QLineEdit" name="lnEd_FwBuildDate">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>71</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>-</string>
+         </property>
+         <property name="maxLength">
+          <number>32</number>
+         </property>
+         <property name="frame">
+          <bool>true</bool>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="readOnly">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="lnEd_FwName">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>181</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>-</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Target:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QLineEdit" name="lnEd_target">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>61</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="frame">
+          <bool>true</bool>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="4">
+        <widget class="QLabel" name="label_9">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>ESP-IDF Version:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="5">
+        <widget class="QLineEdit" name="lnEd_FwIDFVer">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>81</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>-</string>
+         </property>
+         <property name="maxLength">
+          <number>32</number>
+         </property>
+         <property name="frame">
+          <bool>true</bool>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="3" column="4">
+     <widget class="QPushButton" name="pbOk">
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>25</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>OK</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0" colspan="5">
+     <widget class="QTabWidget" name="settingsTab">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <property name="tabsClosable">
+       <bool>false</bool>
+      </property>
+      <widget class="QWidget" name="tab_3">
+       <attribute name="title">
+        <string>Backtrace settings</string>
+       </attribute>
+       <layout class="QGridLayout" name="gridLayout_6">
+        <item row="1" column="0" colspan="10">
+         <widget class="QGroupBox" name="grpBox_Decode">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>69</height>
+           </size>
+          </property>
+          <property name="title">
+           <string>Backtrace form ELF File</string>
+          </property>
+          <property name="checkable">
+           <bool>false</bool>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_4">
+           <item row="1" column="2">
+            <widget class="QPushButton" name="pb_openProjectElf">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>131</width>
+               <height>25</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Select Project ELF</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="2">
+            <widget class="QComboBox" name="comBox_projecElfFile">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>400</width>
+               <height>25</height>
+              </size>
+             </property>
+             <property name="editable">
+              <bool>false</bool>
+             </property>
+             <property name="maxVisibleItems">
+              <number>10</number>
+             </property>
+             <property name="insertPolicy">
+              <enum>QComboBox::InsertAtTop</enum>
+             </property>
+             <property name="minimumContentsLength">
+              <number>2</number>
+             </property>
+             <property name="frame">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item row="3" column="0" colspan="10">
+         <widget class="QGroupBox" name="grpBox_Tools">
+          <property name="minimumSize">
+           <size>
+            <width>500</width>
+            <height>171</height>
+           </size>
+          </property>
+          <property name="title">
+           <string>Decoding Tools</string>
+          </property>
+          <property name="checkable">
+           <bool>false</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_3">
+           <item row="1" column="0">
+            <widget class="QLabel" name="label">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>101</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Addr2Line Path:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_2">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>101</width>
+               <height>19</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Addr2Line Ver:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QLabel" name="label_verReadelf">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1" colspan="2">
+            <widget class="QLineEdit" name="lnEd_pathAddr2Line">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>300</width>
+               <height>25</height>
+              </size>
+             </property>
+             <property name="frame">
+              <bool>true</bool>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+             </property>
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>101</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>ReadElf Path:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="2">
+            <widget class="QPushButton" name="pb_selectReadElf">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>131</width>
+               <height>25</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Select ReadElf</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="2">
+            <widget class="QPushButton" name="pb_selectAddr2Line">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>131</width>
+               <height>25</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Select Addr2Line</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1" colspan="2">
+            <widget class="QLineEdit" name="lnEd_pathReadElf">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>300</width>
+               <height>25</height>
+              </size>
+             </property>
+             <property name="frame">
+              <bool>true</bool>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+             </property>
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLabel" name="label_verAddr2Line">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_3">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>101</width>
+               <height>19</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Readelf Ver:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QCheckBox" name="chkBox_autodetectTools">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="layoutDirection">
+              <enum>Qt::LeftToRight</enum>
+             </property>
+             <property name="text">
+              <string>Autodetect Tools from ELF</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QCheckBox" name="chkBox_invalidResultsEnable">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>21</height>
+           </size>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LeftToRight</enum>
+          </property>
+          <property name="text">
+           <string>Show invalid backtrace results too</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="2" column="4">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="2" column="5">
+         <widget class="QCheckBox" name="chkBox_backtraceDecode">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>21</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LeftToRight</enum>
+          </property>
+          <property name="text">
+           <string>Enable Backtrace Decoder</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tab_4">
+       <attribute name="title">
+        <string>Manual Address Decode</string>
+       </attribute>
+       <layout class="QGridLayout" name="gridLayout_5">
+        <item row="0" column="2">
+         <widget class="QPushButton" name="pb_manualAddrDecode">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>131</width>
+            <height>23</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Decode address</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>81</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Address 
+(or list):</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QTextEdit" name="txtEd_manualAddr">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>1</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>23</height>
+           </size>
+          </property>
+          <property name="acceptRichText">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0" colspan="3">
+         <widget class="QTextEdit" name="txtEd_manualAddrResult">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>4</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tab_5">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <attribute name="title">
+        <string>Readme</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QTextEdit" name="txtEd_Help">
+          <property name="verticalScrollBarPolicy">
+           <enum>Qt::ScrollBarAlwaysOn</enum>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+          <property name="acceptRichText">
+           <bool>false</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+    <item row="3" column="0">
+     <widget class="QPushButton" name="pb_Readme">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>25</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Readme</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
  </widget>
  <resources/>
  <connections/>

--- a/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/snarkdown.js
+++ b/ScriptCommunicator/exampleScripts/WorkerScripts/MainWindowConsole/ESPConsole/snarkdown.js
@@ -1,0 +1,151 @@
+﻿/*************************************************************************
+Snarkdown is a dead simple and extralight Markdown parser.
+
+	It's designed to be as minimal as possible, for constrained use-cases 
+	where a full Markdown parser would be inappropriate.
+	
+Copied and from v2.2.0 source of https://github.com/bpmn-io/snarkdown patched fork 
+of original https://github.com/developit/snarkdown. Using slightly modified source 
+version for better readability and easier integration with ScriptCommunicator.
+	
+	The MIT License (MIT)
+
+Copyright (c) 2017 Jason Miller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+***************************************************************************/
+
+const TAGS = {
+	'': ['<em>','</em>'],
+	_: ['<strong>','</strong>'],
+	'*': ['<strong>','</strong>'],
+	'~': ['<s>','</s>'],
+	'\n': ['<br />'],
+	' ': ['<br />'],
+	'-': ['<hr />']
+};
+
+/** Outdent a string based on the first indented line's leading whitespace
+ *	@private
+ */
+function outdent(str) {
+	return str.replace(RegExp('^'+(str.match(/^(\t| )+/) || '')[0], 'gm'), '');
+}
+
+/** Encode special attribute characters to HTML entities in a String.
+ *	@private
+ */
+function encodeAttr(str) {
+	return (str+'').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/** Parse Markdown into an HTML String. */
+function snarkdown(md, prevLinks) {
+	var tokenizer = /((?:^|\n+)(?:\n---+|\* \*(?: \*)+)\n)|(?:^``` *(\w*)\n([\s\S]*?)\n```$)|((?:(?:^|\n+)(?:\t|  {2,}).+)+\n*)|((?:(?:^|\n)([>*+-]|\d+\.)\s+.*)+)|(?:!\[([^\]]*?)\]\(([^)]+?)\))|(\[)|(\](?:\(([^)]+?)\))?)|(?:(?:^|\n+)([^\s].*)\n(-{3,}|={3,})(?:\n+|$))|(?:(?:^|\n+)(#{1,6})\s*(.+)(?:\n+|$))|(?:`([^`].*?)`)|(  \n\n*|\n{2,}|__|\*\*|[_*]|~~)|<([^>]+)>|\\([_*~])/gm,
+		context = [],
+		out = '',
+		links = prevLinks || {},
+		last = 0,
+		chunk, prev, token, inner, t;
+
+	function tag(token) {
+		var desc = TAGS[token[1] || ''];
+		var end = context[context.length-1] == token;
+		if (!desc) return token;
+		if (!desc[1]) return desc[0];
+		if (end) context.pop();
+		else context.push(token);
+		return desc[end|0];
+	}
+
+	function flush() {
+		var str = '';
+		while (context.length) str += tag(context[context.length-1]);
+		return str;
+	}
+
+	md = md.replace(/^\[(.+?)\]:\s*(.+)$/gm, (s, name, url) => {
+		links[name.toLowerCase()] = url;
+		return '';
+	}).replace(/^\n+|\n+$/g, '');
+	
+	while ( (token=tokenizer.exec(md)) ) {
+		prev = md.substring(last, token.index);
+		last = tokenizer.lastIndex;
+		chunk = token[0];
+		if (prev.match(/[^\\](\\\\)*\\$/)) {
+			// escaped
+		}
+		// Code/Indent blocks:
+		else if (t = (token[3] || token[4])) {
+			chunk = '<pre class="code '+(token[4]?'poetry':token[2].toLowerCase())+'"><code'+(token[2] ? ` class="language-${token[2].toLowerCase()}"` : '')+'>'+outdent(encodeAttr(t).replace(/^\n+|\n+$/g, ''))+'</code></pre>';
+		}
+		// > Quotes, -* lists:
+		else if (t = token[6]) {
+			if (t.match(/\./)) {
+				token[5] = token[5].replace(/^\d+/gm, '');
+			}
+			inner = snarkdown(outdent(token[5].replace(/^\s*[>*+.-]/gm, '')));
+			if (t=='>') t = 'blockquote';
+			else {
+				t = t.match(/\./) ? 'ol' : 'ul';
+				inner = inner.replace(/^(.*)(\n|$)/gm, '<li>$1</li>');
+			}
+			chunk = '<'+t+'>' + inner + '</'+t+'>';
+		}
+		// Images:
+		else if (token[8]) {
+			chunk = `<img src="${encodeAttr(token[8])}" alt="${encodeAttr(token[7])}">`;
+		}
+		// Links:
+		else if (token[10]) {
+			out = out.replace('<a>', `<a href="${encodeAttr(token[11] || links[prev.toLowerCase()])}">`);
+			chunk = flush() + '</a>';
+		}
+		else if (token[18] && /^(https?|mailto):/.test(token[18])) {
+			chunk = `<a href="${encodeAttr(token[18])}">${encodeAttr(token[18])}</a>`;
+		}
+		else if (token[9]) {
+			chunk = '<a>';
+		}
+		// Headings:
+		else if (token[12] || token[14]) {
+			t = 'h' + (token[14] ? token[14].length : (token[13]>'=' ? 1 : 2));
+			chunk = '<'+t+'>' + snarkdown(token[12] || token[15], links) + '</'+t+'>';
+		}
+		// `code`:
+		else if (token[16]) {
+			chunk = '<code>'+encodeAttr(token[16])+'</code>';
+		}
+		// Inline formatting: *em*, **strong** & friends
+		else if (token[17] || token[1]) {
+			chunk = tag(token[17] || '--');
+		}
+
+		// unescape control chars
+		else if (token[19]) {
+			chunk = token[19];
+		}
+
+		out += prev;
+		out += chunk;
+	}
+
+	return (out + md.substring(last) + flush()).replace(/^\n+|\n+$/g, '');
+}


### PR DESCRIPTION
- Added internal "Backtrace:" string search to signalize the backtrace was detected even if it could not be decoded.
- Added checkbox to Show invalid results too (decoded backtrace result is '`?? ??:0`' or '`??:?`')
- Added *Manual Address Decode* tab where user can write selected address(es) and decode them directly. 
- Added *Readme* tab which shows README.md file. Snarkdown JS source is used for markdown formatting. 
- Version info label added